### PR TITLE
Call the right syscall

### DIFF
--- a/syscall/syscall.go
+++ b/syscall/syscall.go
@@ -152,5 +152,5 @@ func JailGet(params [][]byte, flags int) (int, error) {
 }
 
 func JailSet(params [][]byte, flags int) (int, error) {
-	return syscall2(unix.SYS_JAIL_GET, params, flags)
+	return syscall2(unix.SYS_JAIL_SET, params, flags)
 }


### PR DESCRIPTION
The JailSet is calling the SYS_JAIL_GET instead of SYS_JAIL_SET.

This way now calling the gojail.SetParams will work properly :)