### PR TITLE
Add examples and IPv4 support

### DIFF
--- a/examples/attaching/attaching.go
+++ b/examples/attaching/attaching.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+//
+// Copyright (c) 2020 Florian Limberger <flo@purplekraken.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"purplekraken.com/pkg/gojail"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: attaching id")
+		os.Exit(2)
+	}
+	jid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Invalid ID provided: ", err.Error())
+	}
+	err = gojail.Attach(jid)
+
+	if err != nil {
+		if je, ok := err.(*gojail.JailErr); ok {
+			fmt.Fprintln(os.Stderr, "gojail: errmsg:", je)
+		} else if sce, ok := err.(*os.SyscallError); ok {
+			fmt.Fprintln(os.Stderr, "gojail: syscall:", sce)
+		} else {
+			fmt.Fprintln(os.Stderr, "gojail:", err)
+		}
+		os.Exit(1)
+	}
+}

--- a/examples/creating/creating.go
+++ b/examples/creating/creating.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+//
+// Copyright (c) 2020 Florian Limberger <flo@purplekraken.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"purplekraken.com/pkg/gojail"
+	"purplekraken.com/pkg/gojail/syscall"
+)
+
+func main() {
+	if len(os.Args) < 6 {
+		fmt.Fprintln(os.Stderr, "usage: creating name hostname path securelevel ipaddr")
+		os.Exit(2)
+	}
+
+	params := []gojail.JailParam{}
+	name, err := gojail.NewStringParam("name", os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	params = append(params, name)
+
+	hostname, err := gojail.NewStringParam("host.hostname", os.Args[2])
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, hostname)
+
+	path, err := gojail.NewStringParam("path", os.Args[3])
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, path)
+
+	persist, err := gojail.NewStringParam("persist", "")
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, persist)
+
+	secureint, err := strconv.Atoi(os.Args[4])
+	if err != nil || secureint < 0 || secureint > 3 {
+		doError("Invalid securelevel provided, must be a number between 0 and 3")
+	}
+
+	securelevel, err := gojail.NewIntParam("securelevel", secureint)
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, securelevel)
+
+	ip4, err := gojail.NewIPParam(os.Args[5])
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, ip4)
+
+	jid, err := gojail.SetParams(params, syscall.JAIL_CREATE)
+
+	if err != nil {
+		if je, ok := err.(*gojail.JailErr); ok {
+			fmt.Fprintln(os.Stderr, "gojail: errmsg:", je)
+		} else if sce, ok := err.(*os.SyscallError); ok {
+			fmt.Fprintln(os.Stderr, "gojail: syscall:", sce)
+		} else {
+			fmt.Fprintln(os.Stderr, "gojail:", err)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("Created Jail with ID: %d\n", jid)
+
+}
+
+func doError(msg string) {
+	fmt.Fprintln(os.Stderr, "Error parsing the arguments: ", msg)
+	os.Exit(1)
+}

--- a/examples/removing/removing.go
+++ b/examples/removing/removing.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+//
+// Copyright (c) 2020 Florian Limberger <flo@purplekraken.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"purplekraken.com/pkg/gojail"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: removing id")
+		os.Exit(2)
+	}
+	jid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Invalid ID provided: ", err.Error())
+	}
+	err = gojail.Remove(jid)
+
+	if err != nil {
+		if je, ok := err.(*gojail.JailErr); ok {
+			fmt.Fprintln(os.Stderr, "gojail: errmsg:", je)
+		} else if sce, ok := err.(*os.SyscallError); ok {
+			fmt.Fprintln(os.Stderr, "gojail: syscall:", sce)
+		} else {
+			fmt.Fprintln(os.Stderr, "gojail:", err)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("Removed jail with ID: %d\n", jid)
+
+}
+
+func doError(msg string) {
+	fmt.Fprintln(os.Stderr, "Error parsing the arguments: ", msg)
+	os.Exit(1)
+}

--- a/examples/updating/updating.go
+++ b/examples/updating/updating.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+//
+// Copyright (c) 2020 Florian Limberger <flo@purplekraken.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"purplekraken.com/pkg/gojail"
+	"purplekraken.com/pkg/gojail/syscall"
+)
+
+func main() {
+	if len(os.Args) < 5 {
+		fmt.Fprintln(os.Stderr, "updating: gojail name hostname securelevel ipaddr")
+		os.Exit(2)
+	}
+
+	params := []gojail.JailParam{}
+	name, err := gojail.NewStringParam("name", os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	params = append(params, name)
+
+	hostname, err := gojail.NewStringParam("host.hostname", os.Args[2])
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, hostname)
+
+	secureint, err := strconv.Atoi(os.Args[3])
+	if err != nil || secureint < 0 || secureint > 3 {
+		doError("Invalid securelevel provided, must be a number between 0 and 3")
+	}
+
+	securelevel, err := gojail.NewIntParam("securelevel", secureint)
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, securelevel)
+
+	ip4, err := gojail.NewIPParam(os.Args[4])
+	if err != nil {
+		doError(err.Error())
+	}
+	params = append(params, ip4)
+
+	jid, err := gojail.SetParams(params, syscall.JAIL_UPDATE)
+
+	if err != nil {
+		if je, ok := err.(*gojail.JailErr); ok {
+			fmt.Fprintln(os.Stderr, "gojail: errmsg:", je)
+		} else if sce, ok := err.(*os.SyscallError); ok {
+			fmt.Fprintln(os.Stderr, "gojail: syscall:", sce)
+		} else {
+			fmt.Fprintln(os.Stderr, "gojail:", err)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("Updated Jail with ID: %d\n", jid)
+
+}
+
+func doError(msg string) {
+	fmt.Fprintln(os.Stderr, "Error parsing the arguments: ", msg)
+	os.Exit(1)
+}

--- a/syscall/syscall.go
+++ b/syscall/syscall.go
@@ -152,5 +152,5 @@ func JailGet(params [][]byte, flags int) (int, error) {
 }
 
 func JailSet(params [][]byte, flags int) (int, error) {
-	return syscall2(unix.SYS_JAIL_GET, params, flags)
+	return syscall2(unix.SYS_JAIL_SET, params, flags)
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

This PR:

* Adds support for a new function called `NewIPParam` which parses the parameter, and if it's a valid IPv4 adds it as the desired parameter to Jails, converting to uint32, etc etc
* Adds some examples on how to use the library in the folder examples
* Change the `JailSet` function to use the right syscall (SYS_JAIL_SET)

TODO in a future (can open issues to track this, and assign to me if desired)
* Add support for IPv6 - I've miserably failed to know what the syscall expects when it's IPv6
* Create some unit tests for the library
* IF desired, add non-kernel parameters (like pre.start) and also the IP configuration into the library, otherwise document that even if you insert the ip4.addr, you still need to assign this as an alias to your network

Thank you for this nice work with the library :) 